### PR TITLE
Fix formatting of local GUI link in documentation

### DIFF
--- a/como-rsync.md
+++ b/como-rsync.md
@@ -2,4 +2,5 @@ Ver:
 <https://help.resilio.com/hc/en-us/articles/206178924-Installing-Sync-package-on-Linux>
 
 <https://play.google.com/store/apps/details?id=com.resilio.sync&referrer=utm_source%3Dresilio%26utm_medium%3Ddownloads%26utm_campaign%3Dhome&pli=1>
-http://localhost:8888/gui/
+
+<http://localhost:8888/gui/>


### PR DESCRIPTION
Correct the formatting of the local GUI link in the documentation for better clarity.